### PR TITLE
Delete verification tag from x509_cert metrics for compatible vicMetrics.

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -247,12 +247,10 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 
 			_, err = cert.Verify(opts)
 			if err == nil {
-				tags["verification"] = "valid"
 				fields["verification_code"] = 0
 			} else {
-				tags["verification"] = "invalid"
 				fields["verification_code"] = 1
-				fields["verification_error"] = err.Error()
+				//fields["verification_error"] = err.Error()
 			}
 
 			acc.AddFields("x509_cert", fields, tags)


### PR DESCRIPTION
### Required for all PRs:

- [x] Delete verification tag from x509_cert metrics for compatible vicMetrics.